### PR TITLE
Fix NullPointerException for offline players and remove debug message

### DIFF
--- a/src/main/java/de/minnivini/chestshop/listeners/SignListener.java
+++ b/src/main/java/de/minnivini/chestshop/listeners/SignListener.java
@@ -332,7 +332,7 @@ public class SignListener implements Listener {
 
                                                     economy.withdrawPlayer(offlineplayer, Preis);
                                                     economy.depositPlayer(p, Preis);
-                                                    if (offlineplayer.isOnline() || !offlineplayer.equals(p)) {
+                                                    if (offlineplayer.isOnline() && !offlineplayer.equals(p)) {
                                                         offlineplayer.getPlayer().sendMessage(lang.getMessage("hassold").replace("<player>", p.getDisplayName()).replace("<item>", sign.getLine(3).toLowerCase()).replace("<amount>", String.valueOf(amount)));
                                                     }
                                                     p.sendMessage(lang.getMessage("youhassold").replace("<item>", sign.getLine(3).toLowerCase()).replace("<amount>", String.valueOf(amount)) + "(" + (count - amount) + ")");
@@ -355,7 +355,7 @@ public class SignListener implements Listener {
 
                                             economy.withdrawPlayer(p, Preis);
                                             economy.depositPlayer(offlineplayer, Preis);
-                                            if (offlineplayer.isOnline() || !offlineplayer.equals(p)) {
+                                            if (offlineplayer.isOnline() && !offlineplayer.equals(p)) {
                                                 offlineplayer.getPlayer().sendMessage(lang.getMessage("hasbought").replace("<player>", p.getDisplayName()).replace("<item>", sign.getLine(3).toLowerCase()).replace("<amount>", String.valueOf(amount)));
                                             }
                                             p.sendMessage(lang.getMessage("youhasbought").replace("<item>", sign.getLine(3).toLowerCase()).replace("<amount>", String.valueOf(amount)) + "(" + (count - amount) + ")");
@@ -428,7 +428,6 @@ public class SignListener implements Listener {
     private String getPrice(String price) {
         String Preis;
         Preis = price.replace(" (Buying)", "").replaceAll("[ ]", "").replaceAll("[$]", "");
-        System.out.println(Preis);
         Preis = Preis.replaceAll("[^0-9.]", "x");
         if (Preis.contains("x")) Preis = "0";
         return Preis;


### PR DESCRIPTION
### 1 - NullPointerException caused by sending a message to an offline player
The plugin was previously using `||` (OR) instead of `&&` (AND) when checking whether to send a notification to the shop owner:
```java
if (offlineplayer.isOnline() || !offlineplayer.equals(p)) { ... }
````
This could cause an exception if the buyer is different from the shop owner but the owner is offline, because the code attempts to send a message to an offline player.
This condition was fixed to:
```java
if (offlineplayer.isOnline() && !offlineplayer.equals(p)) { ... }
```
The fix was applied for both *Sell* and *Buy* shop types.

### 2 - Removed debug message
A leftover debug message in the `getPrice(String price)` method was printing prices to the console, resulting in excessive messages:
```java
- System.out.println(Preis);
````
This line has been removed.